### PR TITLE
VRoid正式版で腰が曲がることがある問題に対処するため、Chestボーンの高さを変えられるようにした

### DIFF
--- a/Editor/Components/VRChatsBugsWorkaround.cs
+++ b/Editor/Components/VRChatsBugsWorkaround.cs
@@ -73,6 +73,7 @@ namespace Esperecyan.Unity.VRMConverterForVRChat.Components
             GameObject avatar,
             bool enableAutoEyeMovement,
             float addedShouldersPositionY,
+            float addedChestPositionY,
             float addedArmaturePositionY,
             float moveEyeBoneToFrontForEyeMovement,
             bool forQuest
@@ -104,6 +105,7 @@ namespace Esperecyan.Unity.VRMConverterForVRChat.Components
                 avatar: avatar,
                 addedValueToArmature: addedArmaturePositionY,
                 addedValueToShoulders: addedShouldersPositionY,
+                addedValueToChest: addedChestPositionY,
                 addedValueToEyes: moveEyeBoneToFrontForEyeMovement
             );
             if (VRChatUtility.SDKVersion == 2)
@@ -392,6 +394,7 @@ namespace Esperecyan.Unity.VRMConverterForVRChat.Components
         /// • 足が沈む
         /// • なで肩・いかり肩になる
         /// • オートアイムーブメント有効化に伴うウェイト塗り直しで黒目が白目に沈む
+        /// • フルトラ時に腰が横に曲がる
         /// </summary>
         /// <remarks>
         /// 参照:
@@ -404,14 +407,16 @@ namespace Esperecyan.Unity.VRMConverterForVRChat.Components
         /// <param name="addedValueToArmature"></param>
         /// <param name="addedValueToShoulders"></param>
         /// <param name="addedValueToEyes"></param>
+        /// <param name="addedValueToChest"></param>
         private static void AddShouldersPositionYAndEyesPositionZ(
             GameObject avatar,
             float addedValueToArmature,
             float addedValueToShoulders,
+            float addedValueToChest,
             float addedValueToEyes
         )
         {
-            if (addedValueToArmature == 0.0f && addedValueToShoulders == 0.0f && addedValueToEyes == 0.0f)
+            if (addedValueToArmature == 0.0f && addedValueToShoulders == 0.0f && addedValueToEyes == 0.0f && addedValueToChest == 0.0f)
             {
                 return;
             }
@@ -441,6 +446,32 @@ namespace Esperecyan.Unity.VRMConverterForVRChat.Components
                         var name = humanBones.Find(match: humanBone => humanBone.humanName == humanName).boneName;
                         humanDescription.skeleton[skeltonBones.FindIndex(match: skeltonBone => skeltonBone.name == name)].position
                             += new Vector3(0, addedValueToShoulders, 0);
+                    }
+                }
+                if (addedValueToChest != 0.0f)
+                {
+                    if (humanBones.Any(humanBone => humanBone.humanName == "Chest"))
+                    {
+                        {
+                            var name = humanBones.Find(humanBone => humanBone.humanName == "Chest").boneName;
+                            humanDescription.skeleton[skeltonBones.FindIndex(match: skeltonBone => skeltonBone.name == name)].position
+                                += new Vector3(0, addedValueToChest, 0);
+                        }
+
+                        {
+                            List<string> childOfChest;
+                            if (humanBones.Any(humanBone => humanBone.humanName == "UpperChest")) {
+                                childOfChest = new List<string>() { "UpperChest" };
+                            } else {
+                                childOfChest = new List<string>() { "Neck", "LeftShoulder", "RightShoulder" };
+                            }
+
+                            foreach (var boneName in childOfChest) {
+                                var name = humanBones.Find(match: humanBone => humanBone.humanName == boneName).boneName;
+                                humanDescription.skeleton[skeltonBones.FindIndex(match: skeltonBone => skeltonBone.name == name)].position
+                                    += new Vector3(0, -addedValueToChest, 0);
+                            }
+                        }
                     }
                 }
                 if (addedValueToEyes != 0.0f)

--- a/Editor/Converter.cs
+++ b/Editor/Converter.cs
@@ -87,6 +87,7 @@ namespace Esperecyan.Unity.VRMConverterForVRChat
         /// <param name="swayingParametersConverter"></param>
         /// <param name="enableAutoEyeMovement">【SDK2のみ】オートアイムーブメントを有効化するなら<c>true</c>、無効化するなら<c>false</c>。</param>
         /// <param name="addedShouldersPositionY">VRChat上でモデルがなで肩・いかり肩になる問題について、Shoulder/UpperArmボーンのPositionのYに加算する値。</param>
+        /// <param name="addedChestPositionY">VRChat上で腰が曲がる問題について、ChestボーンのPositionのYに加算する値。</param>
         /// <param name="moveEyeBoneToFrontForEyeMovement">【SDK2のみ】オートアイムーブメント有効化時、目ボーンのPositionのZに加算する値。</param>
         /// <param name="forQuest">Quest版用アバター向けに変換するなら <c>true</c>。</param>
         /// <param name="addedArmaturePositionY">VRChat上で足が沈む問題について、Hipsボーンの一つ上のオブジェクトのPositionのYに加算する値。</param>
@@ -104,6 +105,7 @@ namespace Esperecyan.Unity.VRMConverterForVRChat
             SwayingParametersConverter swayingParametersConverter = null,
             bool enableAutoEyeMovement = true,
             float addedShouldersPositionY = 0.0f,
+            float addedChestPositionY = 0.0f,
             float moveEyeBoneToFrontForEyeMovement = 0.0f,
             bool forQuest = false,
             float addedArmaturePositionY = 0.0f,
@@ -145,6 +147,7 @@ namespace Esperecyan.Unity.VRMConverterForVRChat
                 enableAutoEyeMovement: enableAutoEyeMovement,
                 addedShouldersPositionY: addedShouldersPositionY,
                 addedArmaturePositionY: addedArmaturePositionY,
+                addedChestPositionY: addedChestPositionY,
                 moveEyeBoneToFrontForEyeMovement: moveEyeBoneToFrontForEyeMovement,
                 forQuest: forQuest
             ));

--- a/Editor/Locales.cs
+++ b/Editor/Locales.cs
@@ -23,6 +23,7 @@ namespace Esperecyan.Unity.VRMConverterForVRChat
                     { "Take Over Swaying Parameters", "揺れパラメータ引き継ぎ" },
                     { "Shoulder Heights", "肩の高さ" },
                     { "Armature Height", "Armatureの高さ" },
+                    { "Chest Height", "Chestの高さ" },
                     { "Combine Meshes", "メッシュの結合" },
                     { "If you do not “Combine Meshes”,"
                         + " and any of VRMBlendShapes references meshes other than the mesh having most shape keys"

--- a/Editor/UI/Wizard.cs
+++ b/Editor/UI/Wizard.cs
@@ -82,6 +82,12 @@ namespace Esperecyan.Unity.VRMConverterForVRChat.UI
         private float armatureHeight = default;
 
         /// <summary>
+        /// VRChat上で腰が曲がる問題について、ChestボーンのPositionのYに加算する値。
+        /// </summary>
+        [SerializeField, Localizable(-0.1f, 0.1f)]
+        private float chestHeight = default;
+
+        /// <summary>
         /// メッシュ・サブメッシュの結合を行うなら <c>true</c>。
         /// </summary>
         [SerializeField, Localizable]
@@ -635,6 +641,7 @@ namespace Esperecyan.Unity.VRMConverterForVRChat.UI
                 swayingParametersConverter: this.swayingParametersConverter,
                 enableAutoEyeMovement: this.enableEyeMovement,
                 addedShouldersPositionY: this.shoulderHeights,
+                addedChestPositionY: this.chestHeight,
                 moveEyeBoneToFrontForEyeMovement: this.moveEyeBoneToFrontForEyeMovement,
                 forQuest: this.forQuest,
                 addedArmaturePositionY: this.armatureHeight,


### PR DESCRIPTION
VRoid正式版を使うとフルトラ時に腰が曲がることが多いのですが、「Chestボーンの高さを独立して補正できる」とその修正ができるため、機能を追加させてもらえると助かります。

追加した処理は
- UIに補正項目「Chestの高さ」を追加
- 変換実行時に
-- ChestボーンのY位置を補正量だけ加算
-- Chestの子（UpperChestがあればUpperChest、なければNeckとShoulder）のY位置を同じ量だけ補正量だけ減算（Chestの高さのみを変更したいので）
です。

起きている事についてはこちらにまとめました。
https://scrapbox.io/jumius/VRChat%E3%81%AE%E3%83%95%E3%83%AB%E3%83%88%E3%83%A9%E9%81%A9%E6%AD%A3%E3%81%A8VRoid%E6%AD%A3%E5%BC%8F%E7%89%88%E3%81%AE%E8%A9%B1