### PR TITLE
#37 Submeshの数とMaterialの数が一致しないときの例外に対処

### DIFF
--- a/CombineMeshesAndSubMeshes/Editor/CombineMeshesAndSubMeshes.cs
+++ b/CombineMeshesAndSubMeshes/Editor/CombineMeshesAndSubMeshes.cs
@@ -503,7 +503,7 @@ namespace Esperecyan.Unity.VRMConverterForVRChat
                 BindPoses.Add(bindpose);
                 Bones.Add(bone);
 
-                for (int i = 0; i < mesh.subMeshCount; ++i)
+                for (int i = 0; i < mesh.subMeshCount && i < renderer.sharedMaterials.Length; ++i)
                 {
                     var indices = mesh.GetIndices(i).Select(x => x + indexOffset);
                     var mat = renderer.sharedMaterials[i];
@@ -554,7 +554,7 @@ namespace Esperecyan.Unity.VRMConverterForVRChat
                 BindPoses.AddRange(mesh.bindposes);
                 Bones.AddRange(renderer.bones);
 
-                for (int i = 0; i < mesh.subMeshCount; ++i)
+                for (int i = 0; i < mesh.subMeshCount && i < renderer.sharedMaterials.Length; ++i)
                 {
                     var indices = mesh.GetIndices(i).Select(x => x + indexOffset);
                     var mat = renderer.sharedMaterials[i];


### PR DESCRIPTION
SkinnedMeshRenderer に設定されている Materials の Size を手動で変更したとき，本来メッシュに存在するマテリアル数より少ない数を指定している場合に `IndexOutOfRangeException` が発生する．
`mesh.subMeshCount` はメッシュに存在する本来のマテリアル数を返すが，実際にはマテリアルがその数だけ存在しないためエラーとなる．

なお，このとき Unity 上では，マテリアルがセットされていない時（ピンク色の表示）と異なり，マテリアルが指定されなくなった部分のポリゴン（サブメッシュ）が Unity 上で描画されない．
つまり，3D モデルの作者が元々そのような状態でアセットを公開していて対応するマテリアルがそもそも存在しない可能性もある．
そのため，警告文を出して修正するのではなく，見た目通りのまま出力するように，マテリアルの数だけ実行したところでループを終了するように変更した．