### PR TITLE
#43 PhysBone やDB が入っていないアバタで例外が発生するのを修正

### DIFF
--- a/Editor/VRChatToVRM/VRChatToVRMConverter.cs
+++ b/Editor/VRChatToVRM/VRChatToVRMConverter.cs
@@ -333,6 +333,7 @@ namespace Esperecyan.Unity.VRMConverterForVRChat.VRChatToVRM
                 .Select(bone => animator.GetBoneTransform(bone).gameObject);
 
             var objectsHavingUsedColliderGroup = instance.GetComponentsInChildren<VRMSpringBone>()
+                .Where(springBone => springBone.ColliderGroups != null)
                 .SelectMany(springBone => springBone.ColliderGroups)
                 .Select(colliderGroup => colliderGroup.gameObject)
                 .ToArray();


### PR DESCRIPTION
TSIA.

PhysBone 等が一切入っていないアバタでは，(`VRMSpringBone` は `GetComponentsInChilderen` で取得できますが)  `ColliderGroups` が null になっているため，以下のように `NullReferenceException` が発生します．
Null check を入れました．

```
System.NullReferenceException: Object reference not set to an instance of an object
  at System.Linq.Enumerable+SelectManySingleSelectorIterator`2[TSource,TResult].MoveNext () [0x0005e] in <351e49e2a5bf4fd6beabb458ce2255f3>:0 
  at System.Linq.Enumerable+SelectEnumerableIterator`2[TSource,TResult].ToArray () [0x00030] in <351e49e2a5bf4fd6beabb458ce2255f3>:0 
  at System.Linq.Enumerable.ToArray[TSource] (System.Collections.Generic.IEnumerable`1[T] source) [0x0001f] in <351e49e2a5bf4fd6beabb458ce2255f3>:0 
  at Esperecyan.Unity.VRMConverterForVRChat.VRChatToVRM.VRChatToVRMConverter.RemoveUnusedColliderGroups (UnityEngine.GameObject instance) [0x00035] in D:\Workspace\vr\VRCToolTest\Library\PackageCache\jp.pokemori.vrm-converter-for-vrchat@37.0.0\Editor\VRChatToVRM\VRChatToVRMConverter.cs:335 
  at Esperecyan.Unity.VRMConverterForVRChat.VRChatToVRM.VRChatToVRMConverter.Convert (System.String version, System.String outputPath, UnityEngine.GameObject instance, VRM.VRMMetaObject meta, System.Collections.Generic.IDictionary`2[TKey,TValue] presetVRChatBindingPairs, System.Boolean keepUnusedShapeKeys) [0x00239] in D:\Workspace\vr\VRCToolTest\Library\PackageCache\jp.pokemori.vrm-converter-for-vrchat@37.0.0\Editor\VRChatToVRM\VRChatToVRMConverter.cs:187 
  at Esperecyan.Unity.VRMConverterForVRChat.UI.VRChatToVRMWizard.OnWizardCreate () [0x001c4] in D:\Workspace\vr\VRCToolTest\Library\PackageCache\jp.pokemori.vrm-converter-for-vrchat@37.0.0\Editor\UI\VRChatToVRMWizard.cs:292 
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00032] in <eae584ce26bc40229c1b1aa476bfa589>:0 
  at System.Linq.Enumerable+SelectManySingleSelectorIterator`2[TSource,TResult].MoveNext () [0x0005e] in <351e49e2a5bf4fd6beabb458ce2255f3>:0 
  at System.Linq.Enumerable+SelectEnumerableIterator`2[TSource,TResult].ToArray () [0x00030] in <351e49e2a5bf4fd6beabb458ce2255f3>:0 
  at System.Linq.Enumerable.ToArray[TSource] (System.Collections.Generic.IEnumerable`1[T] source) [0x0001f] in <351e49e2a5bf4fd6beabb458ce2255f3>:0 
  at Esperecyan.Unity.VRMConverterForVRChat.VRChatToVRM.VRChatToVRMConverter.RemoveUnusedColliderGroups (UnityEngine.GameObject instance) [0x00035] in D:\Workspace\vr\VRCToolTest\Library\PackageCache\jp.pokemori.vrm-converter-for-vrchat@37.0.0\Editor\VRChatToVRM\VRChatToVRMConverter.cs:335 
  at Esperecyan.Unity.VRMConverterForVRChat.VRChatToVRM.VRChatToVRMConverter.Convert (System.String version, System.String outputPath, UnityEngine.GameObject instance, VRM.VRMMetaObject meta, System.Collections.Generic.IDictionary`2[TKey,TValue] presetVRChatBindingPairs, System.Boolean keepUnusedShapeKeys) [0x00239] in D:\Workspace\vr\VRCToolTest\Library\PackageCache\jp.pokemori.vrm-converter-for-vrchat@37.0.0\Editor\VRChatToVRM\VRChatToVRMConverter.cs:187 
  at Esperecyan.Unity.VRMConverterForVRChat.UI.VRChatToVRMWizard.OnWizardCreate () [0x001c4] in D:\Workspace\vr\VRCToolTest\Library\PackageCache\jp.pokemori.vrm-converter-for-vrchat@37.0.0\Editor\UI\VRChatToVRMWizard.cs:292 
  at (wrapper managed-to-native) System.Reflection.MonoMethod.InternalInvoke(System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00032] in <eae584ce26bc40229c1b1aa476bfa589>:0 
```