### PR TITLE
VRC→VRMで標準Expressions以外を追加出来るように

### DIFF
--- a/Editor/VRChatToVRM/ExpressionPreset.cs
+++ b/Editor/VRChatToVRM/ExpressionPreset.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using System.Collections.Generic;
+
 namespace Esperecyan.Unity.VRMConverterForVRChat.VRChatToVRM
 {
     /// <summary>
@@ -7,35 +9,64 @@ namespace Esperecyan.Unity.VRMConverterForVRChat.VRChatToVRM
     /// <remarks>
     /// https://github.com/vrm-c/vrm-specification/blob/a5cf0747037724d991f9ee4768ea8e07fd8b8f3f/specification/VRMC_vrm-1.0_draft/schema/VRMC_vrm.expression.schema.json
     /// </remarks>
-    public enum ExpressionPreset
+    public class ExpressionPreset
     {
-        Aa,
-        Ih,
-        Ou,
-        Ee,
-        Oh,
+        public static readonly ExpressionPreset Aa = new ExpressionPreset("Aa");
+        public static readonly ExpressionPreset Ih = new ExpressionPreset("Ih");
+        public static readonly ExpressionPreset Ou = new ExpressionPreset("Ou");
+        public static readonly ExpressionPreset Ee = new ExpressionPreset("Ee");
+        public static readonly ExpressionPreset Oh = new ExpressionPreset("Oh");
         /// <summary>
         /// <see cref="VRM.BlendShapePreset.Joy"/> と同じ。
         /// </summary>
-        Happy,
+        public static readonly ExpressionPreset Happy = new ExpressionPreset("Happy");
         /// <summary>
         /// <see cref="VRM.BlendShapePreset.Angry"/> と同じ。
         /// </summary>
-        Angry,
+        public static readonly ExpressionPreset Angry = new ExpressionPreset("Angry");
         /// <summary>
         /// <see cref="VRM.BlendShapePreset.Sorrow"/> と同じ。
         /// </summary>
-        Sad,
+        public static readonly ExpressionPreset Sad = new ExpressionPreset("Sad");
         /// <summary>
         /// <see cref="VRM.BlendShapePreset.Fun"/> と同じ。
         /// </summary>
-        Relaxed,
+        public static readonly ExpressionPreset Relaxed = new ExpressionPreset("Relaxed");
         /// <summary>
         /// 驚いた。VRM-1.0において追加予定の表情。
         /// </summary>
-        Surprised,
-        Blink,
-        BlinkLeft,
-        BlinkRight,
+        public static readonly ExpressionPreset Surprised = new ExpressionPreset("Surprised");
+        public static readonly ExpressionPreset Blink = new ExpressionPreset("Blink");
+        public static readonly ExpressionPreset BlinkLeft = new ExpressionPreset("BlinkLeft");
+        public static readonly ExpressionPreset BlinkRight = new ExpressionPreset("BlinkRight");
+
+        public string Name { get; }
+
+        private ExpressionPreset(string name)
+        {
+            Name = name;
+        }
+
+        public static ExpressionPreset CreateCustom(string name)
+        {
+            return new ExpressionPreset(name);
+        }
+
+        public static IEnumerable<ExpressionPreset> GetAllPresets()
+        {
+            yield return Aa;
+            yield return Ih;
+            yield return Ou;
+            yield return Ee;
+            yield return Oh;
+            yield return Happy;
+            yield return Angry;
+            yield return Sad;
+            yield return Relaxed;
+            yield return Surprised;
+            yield return Blink;
+            yield return BlinkLeft;
+            yield return BlinkRight;
+        }
     }
 }

--- a/Editor/VRChatToVRM/VRChatExpressionsReplacer.cs
+++ b/Editor/VRChatToVRM/VRChatExpressionsReplacer.cs
@@ -141,41 +141,49 @@ namespace Esperecyan.Unity.VRMConverterForVRChat.VRChatToVRM
             return null;
         }
 
-        private static BlendShapeClip GetExpression(BlendShapeAvatar blendShapeAvatar, ExpressionPreset preset)
+        private static BlendShapeClip GetExpression(
+            BlendShapeAvatar blendShapeAvatar,
+            ExpressionPreset preset
+        )
         {
-            switch (preset)
+            if (preset == ExpressionPreset.Aa)
+                return blendShapeAvatar.GetClip(BlendShapePreset.A);
+            if (preset == ExpressionPreset.Ih)
+
+                return blendShapeAvatar.GetClip(BlendShapePreset.I);
+            if (preset == ExpressionPreset.Ou)
+                return blendShapeAvatar.GetClip(BlendShapePreset.U);
+            if (preset == ExpressionPreset.Ee)
+                return blendShapeAvatar.GetClip(BlendShapePreset.E);
+            if (preset == ExpressionPreset.Oh)
+                return blendShapeAvatar.GetClip(BlendShapePreset.O);
+            if (preset == ExpressionPreset.Happy)
+                return blendShapeAvatar.GetClip(BlendShapePreset.Joy);
+            if (preset == ExpressionPreset.Angry)
+                return blendShapeAvatar.GetClip(BlendShapePreset.Angry);
+            if (preset == ExpressionPreset.Sad)
+                return blendShapeAvatar.GetClip(BlendShapePreset.Sorrow);
+            if (preset == ExpressionPreset.Relaxed)
+                return blendShapeAvatar.GetClip(BlendShapePreset.Fun);
+            if (preset == ExpressionPreset.Surprised)
             {
-                case ExpressionPreset.Aa:
-                    return blendShapeAvatar.GetClip(BlendShapePreset.A);
-                case ExpressionPreset.Ih:
-                    return blendShapeAvatar.GetClip(BlendShapePreset.I);
-                case ExpressionPreset.Ou:
-                    return blendShapeAvatar.GetClip(BlendShapePreset.U);
-                case ExpressionPreset.Ee:
-                    return blendShapeAvatar.GetClip(BlendShapePreset.E);
-                case ExpressionPreset.Oh:
-                    return blendShapeAvatar.GetClip(BlendShapePreset.O);
-                case ExpressionPreset.Happy:
-                    return blendShapeAvatar.GetClip(BlendShapePreset.Joy);
-                case ExpressionPreset.Angry:
-                    return blendShapeAvatar.GetClip(BlendShapePreset.Angry);
-                case ExpressionPreset.Sad:
-                    return blendShapeAvatar.GetClip(BlendShapePreset.Sorrow);
-                case ExpressionPreset.Relaxed:
-                    return blendShapeAvatar.GetClip(BlendShapePreset.Fun);
-                case ExpressionPreset.Surprised:
-                    var blendShapeClip = ScriptableObject.CreateInstance<BlendShapeClip>();
-                    blendShapeClip.BlendShapeName = "Surprised";
-                    blendShapeAvatar.Clips.Add(blendShapeClip);
-                    return blendShapeClip;
-                case ExpressionPreset.Blink:
-                    return blendShapeAvatar.GetClip(BlendShapePreset.Blink);
-                case ExpressionPreset.BlinkLeft:
-                    return blendShapeAvatar.GetClip(BlendShapePreset.Blink_L);
-                case ExpressionPreset.BlinkRight:
-                    return blendShapeAvatar.GetClip(BlendShapePreset.Blink_R);
+                var blendShapeClip = ScriptableObject.CreateInstance<BlendShapeClip>();
+                blendShapeClip.BlendShapeName = "Surprised";
+                blendShapeAvatar.Clips.Add(blendShapeClip);
+                return blendShapeClip;
             }
-            throw new ArgumentOutOfRangeException();
+            if (preset == ExpressionPreset.Blink)
+                return blendShapeAvatar.GetClip(BlendShapePreset.Blink);
+            if (preset == ExpressionPreset.BlinkLeft)
+                return blendShapeAvatar.GetClip(BlendShapePreset.Blink_L);
+            if (preset == ExpressionPreset.BlinkRight)
+                return blendShapeAvatar.GetClip(BlendShapePreset.Blink_R);
+
+            // カスタム表情やその他の場合
+            var defaultBlendShapeClip = ScriptableObject.CreateInstance<BlendShapeClip>();
+            defaultBlendShapeClip.BlendShapeName = preset.Name;
+            blendShapeAvatar.Clips.Add(defaultBlendShapeClip);
+            return defaultBlendShapeClip;
         }
     }
 }


### PR DESCRIPTION
VRChat用アバターをVRMに変換する際に、標準のExpressions以外も設定できると嬉しいと感じこの機能を作成しました。
分からない部分はAIに聞きながらやってたのでガバガバだったら申し訳ありません。
個人的に欲しいという機能ではあるので、今後の開発において機能追加をご検討いただけますと幸いです。

<img src="https://github.com/user-attachments/assets/16b6df5a-a102-4faf-9d5a-b22de8badf1a" width="300">


- 変更内容
ExpressionPresetをクラスに変更
カスタムExpression作成用のメソッドを作成