### PR TITLE
[VRChat → VRM] Blinkのシェイプキーがnoneの場合に例外が発生するのを修正

### DIFF
--- a/Editor/Utilities/VRChatUtility.cs
+++ b/Editor/Utilities/VRChatUtility.cs
@@ -325,7 +325,8 @@ namespace Esperecyan.Unity.VRMConverterForVRChat.Utilities
             var settings = instance.GetComponent<VRCAvatarDescriptor>().customEyeLookSettings;
             if (settings.eyelidsSkinnedMesh != null && settings.eyelidsSkinnedMesh.sharedMesh != null
                 && settings.eyelidsBlendshapes != null && settings.eyelidsBlendshapes.Count() == 3
-                && settings.eyelidsSkinnedMesh.sharedMesh.blendShapeCount > settings.eyelidsBlendshapes[0])
+                && settings.eyelidsSkinnedMesh.sharedMesh.blendShapeCount > settings.eyelidsBlendshapes[0]
+                && settings.eyelidsBlendshapes[0] != -1)
             {
                 expressions[ExpressionPreset.Blink] = new VRChatExpressionBinding() {
                     ShapeKeyNames = new[] {


### PR DESCRIPTION
#28 のissueについて修正のPRを作成しました。

こちらの問題の原因ですが、VRC Avatar DescriptorのEye Look→Eyelids→Blendshape StatesのBlinkが`-none-`になっている場合に
以下の`settings.eyelidsBlendshapes[0]`が-1になるためIndex out of rangeが発生していました。
https://github.com/esperecyan/VRMConverterForVRChat/blob/18915174c4d990c2b1774d16eb410163ab499cb1/Editor/Utilities/VRChatUtility.cs#L332

したがって、本修正ではこの値が設定されている場合に無視するようにしています。